### PR TITLE
fix(example): Added `abiFilters 'armeabi-v7a'` to build.gradle

### DIFF
--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -44,6 +44,9 @@ android {
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        ndk {
+             abiFilters 'armeabi-v7a'
+        }
     }
 
     buildTypes {


### PR DESCRIPTION
## Description
As I descripted in #82 `abiFilters 'armeabi-v7a` is not used in the example, but is a part of the setup. So I added it to `app/build.gradle`.

Please check, if everything is correct!

## Related Tickets
Closes #82 