### PR TITLE
docs: Removed unnecessary blank in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ android {
     ..
     defaultConfig {
         ..
-         ndk {
+        ndk {
              abiFilters 'armeabi-v7a'
         }
         ..


### PR DESCRIPTION
## Before
```
defaultConfig {
        ..
         ndk {
             abiFilters 'armeabi-v7a'
        }
        ..
    }
```

## After
```
defaultConfig {
        ..
        ndk {
             abiFilters 'armeabi-v7a'
        }
        ..
    }
```